### PR TITLE
Iterate through symbols once in checkOverrideClashes to improve performance

### DIFF
--- a/src/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2340,7 +2340,9 @@ public class Check {
 
         List<MethodSymbol> potentiallyAmbiguousList = List.nil();
         boolean overridesAny = false;
-        for (Symbol m1 : types.membersClosure(site, false).getElementsByName(sym.name, cf)) {
+        ArrayList<Symbol> symbolsByName = new ArrayList<>();
+        types.membersClosure(site, false).getElementsByName(sym.name, cf).forEach(symbolsByName::add);
+        for (Symbol m1 : symbolsByName) {
             if (!sym.overrides(m1, site.tsym, types, false)) {
                 if (m1 == sym) {
                     continue;
@@ -2358,7 +2360,7 @@ public class Check {
             }
 
             //...check each method m2 that is a member of 'site'
-            for (Symbol m2 : types.membersClosure(site, false).getElementsByName(sym.name, cf)) {
+            for (Symbol m2 : symbolsByName) {
                 if (m2 == m1) continue;
                 //if (i) the signature of 'sym' is not a subsignature of m1 (seen as
                 //a member of 'site') and (ii) m1 has the same erasure as m2, issue an error


### PR DESCRIPTION
Original JDK issue: https://bugs.openjdk.java.net/browse/JDK-8224161
Fix in JDK: http://hg.openjdk.java.net/jdk/jdk/rev/28f4594b19c2
Related IJI issue: https://youtrack.jetbrains.com/issue/IJI-167